### PR TITLE
make Package PHP8 compatible

### DIFF
--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -13,10 +13,11 @@ class CouldNotSendNotification extends \Exception
 
     public static function invalidMessageObject($message)
     {
-        $className = get_class($message) ?: 'Unknown';
+        $className = is_object($message) ? get_class($message) : 'Unknown';
 
         return new static(
-            "Notification was not sent. Message object class `{$className}` is invalid. 
-            It should be `".LogMessage::class.'`');
+            "Notification was not sent. Message object class `{$className}` is invalid.
+            It should be `" . LogMessage::class . '`'
+        );
     }
 }


### PR DESCRIPTION
Hi there, me again.

Just a quick fix to make the package PHP8 compatible (don't know if it works on php 8.1).

changes
---
- fixes the Error that can occur " get_class(): Argument #1 ($object) must be of type object, null given"
- Error happens (from) on PHP8 (7.4 was working fine)



Have a good one! ✌🏽